### PR TITLE
Fix README code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ utc_time = Clock.utc(time)
 local_time = Clock.localized(time, identifier)
 
 milliseconds = Clock.elapsed_milliseconds(start_time, end_time)
+```
 
 ## Dependency Configuration
 


### PR DESCRIPTION
The `README` for this project was missing closing backticks for a code block. This commit adds those backticks.