### PR TITLE
Remove use of timezones other than local and UTC in test suite

### DIFF
--- a/test/automated/substitute.rb
+++ b/test/automated/substitute.rb
@@ -1,7 +1,8 @@
 require_relative 'automated_init'
 
 context "Substitute clock" do
-  now = Time.parse("Jan 1 11:11:11 EDT 2000")
+  now = Clock::Controls::Time::Raw.example
+
   clock_class = Clock::Substitute
 
   context "No assigned time" do

--- a/test/automated/utc.rb
+++ b/test/automated/utc.rb
@@ -27,8 +27,8 @@ context "UTC clock" do
   end
 
   context "Shift timezone to UTC" do
-    local = Time.parse("Jan 1 11:11:11.111 PST 2000")
-    coerced_control = Time.parse("Jan 1 11:11:11.111 UTC 2000")
+    local = Time.local(2000, 1, 1, 11, 11, 11, 111)
+    coerced_control = Time.utc(2000, 1, 1, 11, 11, 11, 111)
 
     coerced = clock.coerce(local)
 


### PR DESCRIPTION
Clock has a few tests that synthesize non-UTC time values for testing conversion to/from UTC time. This change causes those tests to use local time values in those instances, which shouldn't impact the test coverage.

This change is eventually needed to support MRuby, as MRuby's Time class does not have time zone support (beyond local vs UTC).